### PR TITLE
VFFollow Changes

### DIFF
--- a/code/mtsVFFollow.cpp
+++ b/code/mtsVFFollow.cpp
@@ -27,12 +27,12 @@ CMN_IMPLEMENT_SERVICES(mtsVFFollow)
 */
 void mtsVFFollow::FillInTableauRefs(const CONTROLLERMODE mode, const double TickTime)
 {
-//std::cout << "Start FITR" << std::endl;
+
     // fill in refs
     // min || J*dq - [v_T ; v_R] ||
     // v_T = p_des - R_des * R^(-1)_cur * p_cur
     // v_R = sk(A)^(-1) * A - sk(A)^(-1) * R_des * R^(-1)_cur * A
-    // J is the da vinci's jacobian, p_des is the desired frame's translation,
+    // J is the jacobian, p_des is the desired frame's translation,
     // R_des is the desired frame's rotation, R^(-1)_cur is the inverse of the current frame's rotation,
     // p_cur is the current frame's translation, A is an arbitrary vector, sk(A)^(-1) is the inverse of the skew matrix of A
 
@@ -62,13 +62,46 @@ void mtsVFFollow::FillInTableauRefs(const CONTROLLERMODE mode, const double Tick
     // Translation Part
     dx_translation = DesiredFrame.Translation() - CurrentFrame.Translation();
 
+    // Resized jacobian
+    vctDoubleMat JacResized(CurrentKinematics->Jacobian.rows(),CurrentKinematics->Jacobian.cols());
+    JacResized.Assign(CurrentKinematics->Jacobian);
+    JacResized.resize(3,CurrentKinematics->Jacobian.cols());
 
-    // Delta x
-    ObjectiveVectorRef.Assign(dx_translation);
-    // Put Jacobian into matrix ref
-    ObjectiveMatrixRef.Assign(CurrentKinematics->Jacobian);
+    // Rotation part
+    vctAxAnRot3 dxRot;
+    vct3 dxRotVec;
+    dxRot.FromNormalized((CurrentFrame.Inverse() * DesiredFrame).Rotation());
+    dxRotVec = dxRot.Axis() * dxRot.Angle();
+    dx_rotation[0] = dxRotVec[0];
+    dx_rotation[1] = dxRotVec[1];
+    dx_rotation[2] = dxRotVec[2];
+    dx_rotation = CurrentFrame.Rotation() * dx_rotation;
+
+    // Constructing the dx parameter
+    vctDoubleVec dx(6);
+    std::copy(dx_translation.begin(), dx_translation.end(), dx.begin() );
+    std::copy(dx_rotation.begin() , dx_rotation.end() , dx.begin()+3);
+
+
+    if(Data->ObjectiveRows == 3)
+    {
+        // Delta x
+        ObjectiveVectorRef.Assign(dx_translation);
+        // Put Jacobian into matrix ref
+        ObjectiveMatrixRef.Assign(JacResized);
+    }
+    else if(Data->ObjectiveRows == 6)
+    {
+        ObjectiveVectorRef.Assign(dx);
+        ObjectiveMatrixRef.Assign(CurrentKinematics->Jacobian);
+    }
+    else
+    {
+        CMN_LOG_CLASS_RUN_ERROR << "FillInTableauRefs: Follow VF given improper number of rows" << std::endl;
+        cmnThrow("FillInTableauRefs: Follow VF given improper number of rows");
+    }
 
     // make conversion, if necessary
     ConvertRefs(mode,TickTime);
-//std::cout << "End" << std::endl;
+
 }

--- a/code/mtsVF_RCM.cpp
+++ b/code/mtsVF_RCM.cpp
@@ -4,7 +4,7 @@ CMN_IMPLEMENT_SERVICES(mtsVF_RCM);
 
 void mtsVF_RCM::FillInTableauRefs(const CONTROLLERMODE mode, const double TickTime)
 {
-//std::cout << "Entering RCM" << std::endl;
+
     mtsVFDataRCM * RCM_Data = (mtsVFDataRCM*)(Data);
 
     // Constraint-Based RCM
@@ -17,33 +17,6 @@ void mtsVF_RCM::FillInTableauRefs(const CONTROLLERMODE mode, const double TickTi
     IneqConstraintMatrixRef.Assign(RCM_Mat);
     IneqConstraintVectorRef.Assign(h);
 
-
-    // Objective-Based RCM
-
-    //vct3 RCM_Offset_Base = RCM_Data->TipFrame.Translation(); // TODO temporary use of this variable
-    //vct3 dx_translation = RCM_Data->RCM_Point - RCM_Offset_Base;
-    //vct3 dx_rotation;
-    //vctAxAnRot3 dxRot;
-    //vct3 dxRotVec;
-    //dxRot.FromNormalized(RCM_Data->TipFrame.Rotation());
-    //dxRotVec = dxRot.Axis() * dxRot.Angle();
-    //dx_rotation[0] = dxRotVec[0];
-    //dx_rotation[1] = dxRotVec[1];
-    //dx_rotation[2] = dxRotVec[2];
-
-    //vctDoubleVec dx(6);
-    //std::copy(dx_translation.begin(), dx_translation.end(), dx.begin()  );
-    //std::copy(dx_rotation.begin()   , dx_rotation.end()   , dx.begin()+3);    
-
-    //vctDoubleMat JacResized = RCM_Data->JacClosest;
-    //JacResized.resize(3,7);
-    //JacResized.Column(6).SetAll(0.0);
-    //ObjectiveMatrixRef.Assign(JacResized);
-    //ObjectiveVectorRef.Assign(dx_translation);    
-
-    //std::cout << "H*JacClosest \n" << IneqConstraintMatrixRef << std::endl;
-    //std::cout << "h \n" << IneqConstraintVectorRef << std::endl;
-
     // ConvertRefs(mode,TickTime);
-//std::cout << "Leaving RCM" << std::endl;
+
 }


### PR DESCRIPTION
Removed unused code from RCM, added separate cases for pure translation and both translation and rotation in follow VF. If 3 rows are specified, it will only use the translational jacobian. If 6 are specified, it will use the full jacobian. I may also add another case for pure rotation.